### PR TITLE
Make pip upgrade work for Windows 10 and latest python binary.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.10
+version=0.1.10-ccb
 
 # These are just placeholder values.
 artifactoryUser='set in user gradle.properties'

--- a/src/main/groovy/com/analog/garage/pygrad/PythonVirtualEnvTask.groovy
+++ b/src/main/groovy/com/analog/garage/pygrad/PythonVirtualEnvTask.groovy
@@ -535,10 +535,20 @@ if sys.hexversion < 0x030400F0:
 	}
 	
 	void pipUpgrade(String pkg) {
-		def installArgs = pipInstallArgs + ['--upgrade', pkg]
-		project.exec {
-			executable = venv.pipExe
-			args = installArgs
+		// If we are upgrading pip, do it this way...makes it work for Python3 on Windows 10
+		// (and probably all other platforms)
+		if (pkg == 'pip'){
+			def installArgs = ['-m', 'pip', 'install', '--upgrade', 'pip']
+			project.exec {
+				executable = venv.pythonExe
+				args = installArgs
+			}
+		} else {
+			def installArgs = pipInstallArgs + ['--upgrade', pkg]
+			project.exec {
+				executable = venv.pipExe
+				args = installArgs
+			}
 		}
 	}
 	

--- a/src/test/projects/simple/build.gradle
+++ b/src/test/projects/simple/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.os.OperatingSystem;
+
 plugins {
 	id 'com.analog.garage.pygrad'
 }
@@ -16,4 +18,10 @@ project.version = '1.2-SNAPSHOT'
 python {
 	sourceDir = "$project.rootDir"
 	versionFile = "version.py"
+	// On Windows 10, with lastest Python binary installed (V3), the installer does not
+	// install python3, but instead python, which is unlike linux.  ARG!  Python is a 
+	// hot mess!
+	if (OperatingSystem.current().isWindows()) {
+		pythonExe = "python"
+	}
 }


### PR DESCRIPTION
I attempted to use this plugin with Windows 10 and latest 64-bit Python msi installed.  Pip upgrade failed because, on Windows anyway, pip cannot upgrade itself.  Also, test project required mod because python3 installed on Windows is just 'python'.  Tests passed and I executed fixes to a local project and it now works.